### PR TITLE
Updated data type change handling

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,7 +9,7 @@ description: Connect your data sources to SingleStore using Fivetran in just min
 
 [SingleStore](https://www.singlestore.com/) is a distributed, cloud-native database that can handle transactional and analytical workloads with a unified engine. It provides real-time analytics, transactions, and streaming capabilities, enabling users to handle diverse workloads on a single platform. 
 
-You can use Fivetran, to ingest data from various sources into SingleStore for unified analytics and insights. 
+You can use Fivetran to ingest data from various sources into SingleStore for unified analytics and insights. 
 
 > NOTE: This destination is [partner-built](/docs/partner-built-program). For any questions related to SingleStore destination and its documentation, contact SingleStore by raising an issue in the [SingleStore Fivetran Destination](https://github.com/singlestore-labs/singlestore-fivetran-destination) GitHub repository.
 
@@ -23,7 +23,7 @@ Follow our step-by-step [SingleStore Setup Guide](/docs/destinations/singlestore
 
 ## Type Transformation Mapping
 
-While extracting data from your data source using Fivetran, SingleStore matches Fivetran data types to SingleStore data types. If a data type isn't supported, it is automatically typecasted to the closest supported SingleStore data type.
+While extracting data from your data source using Fivetran, SingleStore matches Fivetran data types to SingleStore data types. If a data type isn't supported, it is automatically typecast to the closest supported SingleStore data type.
 
 The following table illustrates how Fivetran data types are transformed into SingleStore supported types:
 
@@ -48,8 +48,9 @@ The following table illustrates how Fivetran data types are transformed into Sin
 
 ## Schema Changes
 
-| Schema Change      | Supported | Notes                                                                                                     |
-|--------------------|-----------|-----------------------------------------------------------------------------------------------------------|
-| Add column         | ✔       | When Fivetran detects the addition of a column in your source, it automatically adds that column in SingleStore. |
-| Change column type | ✔       | When Fivetran detects a change in the column type in the data source, it automatically changes column type in SingleStore. To change the column type, Fivetran creates a new column, copies the data from the existing column to the new column, deletes the existing column, and renames the new column. |
----
+| Schema Change          | Supported | Notes                                                                                                     |
+|------------------------|-----------|-----------------------------------------------------------------------------------------------------------|
+| Add column             | ✔       | When Fivetran detects the addition of a column in your source, it automatically adds that column in the SingleStore destination. |
+| Change column type     | ✔       | When Fivetran detects a change in the column type in the data source, it automatically changes the column type in the SingleStore destination. To change the column type, Fivetran creates a new column, copies the data from the existing column to the new column, deletes the existing column, and renames the new column. |
+| Change key             | ✘      | Changing PRIMARY KEY is not supported in SingleStore. |
+| Change key column type | ✘      | Changing PRIMARY KEY column data type is not supported in SingleStore. |

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -21,7 +21,7 @@ To deploy a Self-Managed cluster instead, refer to [Deploy](https://docs.singles
     - `Port`: Default is `3306`
     - `Username`: Username of the SingleStore database user
     - `Password`: Password of the SingleStore database user    
-- A Fivetran account with [permission to add destinations](/docs/using-fivetran/fivetran-dashboard/account-management/role-based-access-control#legacyandnewrbacmodel).
+- A Fivetran account with the [Create Destinations or Manage Destinations](/docs/using-fivetran/fivetran-dashboard/account-management/role-based-access-control#rbacpermissions) permissions.
 
 
 ---
@@ -40,7 +40,7 @@ To deploy a Self-Managed cluster instead, refer to [Deploy](https://docs.singles
     * `ALTER`
     * `CREATE DATABASE`
 
-### <span class="step-item">Configure Fivetran </span>
+### <span class="step-item">Complete Fivetran configuration</span>
 
 1. Log in to your Fivetran account.
 2. Go to the [**Destinations** page](https://fivetran.com/dashboard/destinations), and then click **+ Add Destination**.
@@ -52,7 +52,7 @@ To deploy a Self-Managed cluster instead, refer to [Deploy](https://docs.singles
     * **Username**
     * **Password**
 6. (Optional) Enable SSL and specify related configurations.
-7. (Optional) Specify additional **Driver Parameters**. Refer to [The SingleStore JDBC Driver](https://docs.singlestore.com/cloud/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver/#connection-string-parameters) for a list of supported parameters.
+7. (Optional) Specify additional **Driver Parameters**. Refer to [The SingleStore JDBC Driver](https://docs.singlestore.com/cloud/developer-resources/connect-with-application-development-tools/connect-with-java-jdbc/the-singlestore-jdbc-driver/#connection-string-parameters) documentation for a list of supported parameters.
 8. Select the **Data processing location**.
 9. Select your **Time zone**.
 10. Click **Save & Test**.

--- a/src/main/java/com/singlestore/fivetran/destination/JDBCUtil.java
+++ b/src/main/java/com/singlestore/fivetran/destination/JDBCUtil.java
@@ -181,8 +181,16 @@ public class JDBCUtil {
             Column oldColumn = oldColumns.get(column.getName());
             if (oldColumn == null) {
                 columnsToAdd.add(column);
-            } else if (!oldColumn.equals(column)) {
-                columnsToChange.add(column);
+            } else {
+                String oldType = mapDataTypes(oldColumn.getType(), oldColumn.getDecimal());
+                String newType = mapDataTypes(column.getType(), column.getDecimal());
+                if (!oldType.equals(newType)) {
+                    if (oldColumn.getPrimaryKey()) {
+                        throw new Exception(
+                                "Changing PRIMARY KEY column data type is not supported in SingleStore");
+                    }
+                    columnsToChange.add(column);
+                }
             }
         }
 


### PR DESCRIPTION
When the PK data type is changed - an error is thrown.
When the Fivetran data type is changed but the new type corresponds to the same SingleStore type - nothing is done.
Updated docs.