### PR TITLE
Added check that PK exists

### DIFF
--- a/data-folder/batch.json
+++ b/data-folder/batch.json
@@ -67,7 +67,7 @@
             }
         },
         {
-            "hard_truncate_before": [
+            "truncate_before": [
                 "campaign"
             ]
         },
@@ -82,7 +82,7 @@
             }
         },
         {
-            "truncate_before": [
+            "soft_truncate_before": [
                 "transaction"
             ]
         },
@@ -114,15 +114,23 @@
                 "transaction": [
                     {
                         "id": 3
-                    },
-                    {
-                        "id": 4
                     }
                 ],
                 "campaign": [
                     {
                         "_fivetran_id": "abc-123-xyz"
-                    },
+                    }
+                ]
+            }
+        },
+        {
+            "soft_delete": {
+                "transaction": [
+                    {
+                        "id": 4
+                    }
+                ],
+                "campaign": [
                     {
                         "_fivetran_id": "dfg-890-lkj"
                     }

--- a/src/main/java/com/singlestore/fivetran/destination/SingleStoreDestinationServiceImpl.java
+++ b/src/main/java/com/singlestore/fivetran/destination/SingleStoreDestinationServiceImpl.java
@@ -213,6 +213,11 @@ public class SingleStoreDestinationServiceImpl extends DestinationGrpc.Destinati
         SingleStoreConfiguration conf = new SingleStoreConfiguration(request.getConfigurationMap());
 
         try (Connection conn = JDBCUtil.createConnection(conf);) {
+            if (request.getTable().getColumnsList().stream()
+                    .allMatch(column -> !column.getPrimaryKey())) {
+                throw new Exception("No primary key found");
+            }
+
             LoadDataWriter w = new LoadDataWriter(conn, request.getSchemaName(), request.getTable(),
                     request.getCsv(), request.getKeysMap());
             for (String file : request.getReplaceFilesList()) {

--- a/src/main/java/com/singlestore/fivetran/destination/SingleStoreDestinationServiceImpl.java
+++ b/src/main/java/com/singlestore/fivetran/destination/SingleStoreDestinationServiceImpl.java
@@ -214,7 +214,7 @@ public class SingleStoreDestinationServiceImpl extends DestinationGrpc.Destinati
 
         try (Connection conn = JDBCUtil.createConnection(conf);) {
             if (request.getTable().getColumnsList().stream()
-                    .allMatch(column -> !column.getPrimaryKey())) {
+                    .noneMatch(column -> column.getPrimaryKey())) {
                 throw new Exception("No primary key found");
             }
 


### PR DESCRIPTION
When PK doesn't exist, it may cause issues with update or delete queries.
Other destinations also throw an error in this case. See motherduck as an example [https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/blob/cec99[…]0c00a5d57bb8ff143bf38769b/src/motherduck_destination_server.cpp](https://github.com/MotherDuck-Open-Source/motherduck-fivetran-connector/blob/cec99df33cbdb0e0c00a5d57bb8ff143bf38769b/src/motherduck_destination_server.cpp#L347C1-L349C6)