### PR TITLE
Recreated table from scratch when PK changes

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -50,7 +50,6 @@ The following table illustrates how Fivetran data types are transformed into Sin
 
 | Schema Change          | Supported | Notes                                                                                                     |
 |------------------------|-----------|-----------------------------------------------------------------------------------------------------------|
-| Add column             | ✔       | When Fivetran detects the addition of a column in your source, it automatically adds that column in the SingleStore destination. |
-| Change column type     | ✔       | When Fivetran detects a change in the column type in the data source, it automatically changes the column type in the SingleStore destination. To change the column type, Fivetran creates a new column, copies the data from the existing column to the new column, deletes the existing column, and renames the new column. |
-| Change key             | ✘      | Changing PRIMARY KEY is not supported in SingleStore. |
-| Change key column type | ✘      | Changing PRIMARY KEY column data type is not supported in SingleStore. |
+| Add column                    | ✔       | When Fivetran detects the addition of a column in your source, it automatically adds that column in the SingleStore destination. |
+| Change column type            | ✔       | When Fivetran detects a change in the column type in the data source, it automatically changes the column type in the SingleStore destination. To change the column type, Fivetran creates a new column, copies the data from the existing column to the new column, deletes the existing column, and renames the new column. |
+| Change key or key column type | ✔       | Changing PRIMARY KEY is not supported in SingleStore. When Fivetran detects a change in a key, it creates a new table with updated PRIMARY KEY, copies the data from the existing table to the new one, deletes the existing table, and renames the new table |

--- a/src/test/java/com/singlestore/fivetran/destination/AlterTableTest.java
+++ b/src/test/java/com/singlestore/fivetran/destination/AlterTableTest.java
@@ -93,9 +93,15 @@ public class AlterTableTest extends IntegrationTestBase {
             AlterTableRequest request = AlterTableRequest.newBuilder().putAllConfiguration(confMap)
                     .setSchemaName(database).setTable(table).build();
 
-            Exception ex =
-                    assertThrows(Exception.class, () -> JDBCUtil.generateAlterTableQuery(request));
-            assertEquals("Changing PRIMARY KEY is not supported in SingleStore", ex.getMessage());
+            String query = JDBCUtil.generateAlterTableQuery(request);
+            stmt.execute(query);
+            Table result = JDBCUtil.getTable(conf, database, "changeTypeOfKey", "changeTypeOfKey");
+            List<Column> columns = result.getColumnsList();
+
+            assertEquals("a", columns.get(0).getName());
+            assertEquals(DataType.INT, columns.get(0).getType());
+            assertEquals(true, columns.get(0).getPrimaryKey());
+
         }
     }
 

--- a/src/test/java/com/singlestore/fivetran/destination/AlterTableTest.java
+++ b/src/test/java/com/singlestore/fivetran/destination/AlterTableTest.java
@@ -95,7 +95,7 @@ public class AlterTableTest extends IntegrationTestBase {
 
             String query = JDBCUtil.generateAlterTableQuery(request);
             stmt.execute(query);
-            Table result = JDBCUtil.getTable(conf, database, "changeTypeOfKey", "changeTypeOfKey");
+            Table result = JDBCUtil.getTable(conf, database, "changeKey", "changeKey");
             List<Column> columns = result.getColumnsList();
 
             assertEquals("a", columns.get(0).getName());

--- a/src/test/java/com/singlestore/fivetran/destination/AlterTableTest.java
+++ b/src/test/java/com/singlestore/fivetran/destination/AlterTableTest.java
@@ -119,7 +119,8 @@ public class AlterTableTest extends IntegrationTestBase {
 
             String query = JDBCUtil.generateAlterTableQuery(request);
             stmt.execute(query);
-            Table result = JDBCUtil.getTable(conf, database, "severalOperations", "severalOperations");
+            Table result =
+                    JDBCUtil.getTable(conf, database, "severalOperations", "severalOperations");
             List<Column> columns = result.getColumnsList();
 
             assertEquals("a", columns.get(0).getName());
@@ -158,7 +159,8 @@ public class AlterTableTest extends IntegrationTestBase {
 
             String query = JDBCUtil.generateAlterTableQuery(request);
             stmt.execute(query);
-            Table result = JDBCUtil.getTable(conf, database, "changeScaleAndPrecision", "changeScaleAndPrecision");
+            Table result = JDBCUtil.getTable(conf, database, "changeScaleAndPrecision",
+                    "changeScaleAndPrecision");
             List<Column> columns = result.getColumnsList();
 
             assertEquals("a", columns.get(0).getName());
@@ -209,18 +211,33 @@ public class AlterTableTest extends IntegrationTestBase {
                 Statement stmt = conn.createStatement();) {
             stmt.execute(String.format("USE %s", database));
             stmt.execute("CREATE TABLE changeTypeOfKey(a INT PRIMARY KEY)");
+            stmt.execute("INSERT INTO changeTypeOfKey VALUES (1), (2)");
             Table table = Table.newBuilder().setName("changeTypeOfKey")
                     .addAllColumns(Arrays.asList(Column.newBuilder().setName("a")
                             .setType(DataType.LONG).setPrimaryKey(true).build()))
+                    .addAllColumns(Arrays.asList(
+                            Column.newBuilder().setName("b").setType(DataType.LONG).build()))
                     .build();
 
             AlterTableRequest request = AlterTableRequest.newBuilder().putAllConfiguration(confMap)
                     .setSchemaName(database).setTable(table).build();
 
-            Exception ex =
-                    assertThrows(Exception.class, () -> JDBCUtil.generateAlterTableQuery(request));
-            assertEquals("Changing PRIMARY KEY column data type is not supported in SingleStore",
-                    ex.getMessage());
+            String query = JDBCUtil.generateAlterTableQuery(request);
+
+            stmt.execute(query);
+            Table result = JDBCUtil.getTable(conf, database, "changeTypeOfKey", "changeTypeOfKey");
+            List<Column> columns = result.getColumnsList();
+
+            assertEquals("a", columns.get(0).getName());
+            assertEquals(DataType.LONG, columns.get(0).getType());
+            assertEquals(true, columns.get(0).getPrimaryKey());
+
+            assertEquals("b", columns.get(1).getName());
+            assertEquals(DataType.LONG, columns.get(1).getType());
+            assertEquals(false, columns.get(1).getPrimaryKey());
+
+            checkResult("SELECT * FROM `changeTypeOfKey` ORDER BY a",
+                    Arrays.asList(Arrays.asList("1", null), Arrays.asList("2", null)));
         }
     }
 }

--- a/src/test/java/com/singlestore/fivetran/destination/IntegrationTestBase.java
+++ b/src/test/java/com/singlestore/fivetran/destination/IntegrationTestBase.java
@@ -17,7 +17,7 @@ public class IntegrationTestBase {
     static String host = "127.0.0.1";
     static String port = "3306";
     static String user = "root";
-    static String password = System.getenv("ROOT_PASSWORD");
+    static String password = "password";
     static String database = "db";
 
     static ImmutableMap<String, String> confMap =

--- a/src/test/java/com/singlestore/fivetran/destination/IntegrationTestBase.java
+++ b/src/test/java/com/singlestore/fivetran/destination/IntegrationTestBase.java
@@ -17,7 +17,7 @@ public class IntegrationTestBase {
     static String host = "127.0.0.1";
     static String port = "3306";
     static String user = "root";
-    static String password = "password";
+    static String password = System.getenv("ROOT_PASSWORD");
     static String database = "db";
 
     static ImmutableMap<String, String> confMap =


### PR DESCRIPTION
Fivetran requires the support of key changes. Even if this operation is not optimal