### PR TITLE
Removed new line characters from logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ gradle jar
 ```
 2. Run the Jar
 ```
-java -jar build/libs/singlestore-fivetran-destination.jar 
+java -jar build/libs/singlestore-fivetran-destination-1.0.3.jar 
 ```
 
 ## Steps for running Java tests

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
         <onMismatch>DENY</onMismatch>
     </filter>
     <encoder>
-      <pattern>{"level":"INFO", "message": "%m", "message-origin": "sdk_destination"}%n</pattern>
+      <pattern>{"level":"INFO", "message": "%replace(%m){'[\r\n]+', ' '}", "message-origin": "sdk_destination"}%n</pattern>
     </encoder>
   </appender>
   <appender name="STDOUT-WARN" class="ch.qos.logback.core.ConsoleAppender">
@@ -16,7 +16,7 @@
         <onMismatch>DENY</onMismatch>
     </filter>
     <encoder>
-      <pattern>{"level":"WARNING", "message": "%m", "message-origin": "sdk_destination"}%n</pattern>
+      <pattern>{"level":"WARNING", "message": "%replace(%m){'[\r\n]+', ' '}", "message-origin": "sdk_destination"}%n</pattern>
     </encoder>
   </appender>
   <appender name="STDOUT-SEVERE" class="ch.qos.logback.core.ConsoleAppender">
@@ -26,7 +26,7 @@
         <onMismatch>DENY</onMismatch>
     </filter>
     <encoder>
-      <pattern>{"level":"SEVERE", "message": "%m", "message-origin": "sdk_destination"}%n</pattern>
+      <pattern>{"level":"SEVERE", "message": "%replace(%m){'[\r\n]+', ' '}", "message-origin": "sdk_destination"}%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Fivetran logs incorrectly handle newline characters, making the debugging process much harder.