### PR TITLE
Fix setting of default configuration values

### DIFF
--- a/src/main/java/com/singlestore/fivetran/destination/JDBCUtil.java
+++ b/src/main/java/com/singlestore/fivetran/destination/JDBCUtil.java
@@ -16,7 +16,9 @@ public class JDBCUtil {
     static Connection createConnection(SingleStoreConfiguration conf) throws Exception {
         Properties connectionProps = new Properties();
         connectionProps.put("user", conf.user());
-        connectionProps.put("password", conf.password());
+        if (conf.password() != null) {
+            connectionProps.put("password", conf.password());
+        }
         connectionProps.put("allowLocalInfile", "true");
         connectionProps.put("transformedBitIsBoolean", "true");
         connectionProps.put("allowMultiQueries", "true");
@@ -24,12 +26,11 @@ public class JDBCUtil {
                 String.format("_connector_name:%s,_connector_version:%s",
                         "SingleStore Fivetran Destination", VersionProvider.getVersion()));
 
-        if (conf.sslMode() != null) {
-            connectionProps.put("sslMode", conf.sslMode());
-            if (!conf.sslMode().equals("disable")) {
-                putIfNotEmpty(connectionProps, "serverSslCert", conf.sslServerCert());
-            }
+        connectionProps.put("sslMode", conf.sslMode());
+        if (!conf.sslMode().equals("disable")) {
+            putIfNotEmpty(connectionProps, "serverSslCert", conf.sslServerCert());
         }
+        
         String driverParameters = conf.driverParameters();
         if (driverParameters != null) {
             for (String parameter : driverParameters.split(";")) {

--- a/src/main/java/com/singlestore/fivetran/destination/SingleStoreConfiguration.java
+++ b/src/main/java/com/singlestore/fivetran/destination/SingleStoreConfiguration.java
@@ -16,13 +16,25 @@ public class SingleStoreConfiguration {
     SingleStoreConfiguration(Map<String, String> conf) {
         this.host = conf.get("host");
         this.port = Integer.valueOf(conf.get("port"));
-        this.database = conf.get("database");
+        this.database = withDefaultNull(conf.get("database"));
         this.user = conf.get("user");
-        this.password = conf.get("password");
-        this.sslMode = conf.get("ssl.mode");
-        this.sslServerCert = conf.get("ssl.server.cert");
-        this.driverParameters = conf.get("driver.parameters");
-        this.batchSize = Integer.valueOf(conf.getOrDefault("batchSize", "10000"));
+        this.password = withDefaultNull(conf.get("password"));
+        this.sslMode = withDefault(conf.get("ssl.mode"), "disable");
+        this.sslServerCert = withDefaultNull(conf.get("ssl.server.cert"));
+        this.driverParameters = withDefaultNull(conf.get("driver.parameters"));
+        this.batchSize = Integer.valueOf(withDefault(conf.get("batch.size"), "10000"));
+    }
+
+    private String withDefault(String s, String def) {
+        if (s == null || s.isEmpty()) {
+            return def;
+        }
+
+        return s;
+    }
+
+    private String withDefaultNull(String s) {
+        return withDefault(s, null);
     }
 
     public String host() {

--- a/src/main/java/com/singlestore/fivetran/destination/writers/DeleteWriter.java
+++ b/src/main/java/com/singlestore/fivetran/destination/writers/DeleteWriter.java
@@ -68,6 +68,7 @@ public class DeleteWriter extends Writer {
             }
         }
 
+        System.out.println(query.toString());
         try (PreparedStatement stmt = conn.prepareStatement(query.toString())) {
             for (int i = 0; i < rows.size(); i++) {
                 List<String> row = rows.get(i);

--- a/src/main/java/com/singlestore/fivetran/destination/writers/DeleteWriter.java
+++ b/src/main/java/com/singlestore/fivetran/destination/writers/DeleteWriter.java
@@ -68,7 +68,6 @@ public class DeleteWriter extends Writer {
             }
         }
 
-        System.out.println(query.toString());
         try (PreparedStatement stmt = conn.prepareStatement(query.toString())) {
             for (int i = 0; i < rows.size(); i++) {
                 List<String> row = rows.get(i);

--- a/src/test/java/com/singlestore/fivetran/destination/JDBCUtilTest.java
+++ b/src/test/java/com/singlestore/fivetran/destination/JDBCUtilTest.java
@@ -1,5 +1,7 @@
 package com.singlestore.fivetran.destination;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import java.sql.Connection;
 import java.sql.Statement;
 
@@ -10,12 +12,28 @@ import com.google.common.collect.ImmutableMap;
 public class JDBCUtilTest extends IntegrationTestBase {
     @Test
     public void driverParameters() throws Exception {
-        SingleStoreConfiguration conf = new SingleStoreConfiguration(ImmutableMap.of("host",
-                host, "port", port, "user", user, "password", password, "driverParameters",
+        SingleStoreConfiguration conf = new SingleStoreConfiguration(ImmutableMap.of("host", host,
+                "port", port, "user", user, "password", password, "driver.parameters",
                 "cachePrepStmts = TRUE; allowMultiQueries=  TRUE ;connectTimeout = 20000"));
         try (Connection conn = JDBCUtil.createConnection(conf);
                 Statement stmt = conn.createStatement();) {
             stmt.executeQuery("SELECT 1; SELECT 2");
         }
+    }
+
+    @Test
+    public void defaultValues() throws Exception {
+        SingleStoreConfiguration conf = new SingleStoreConfiguration(ImmutableMap.of("host", host,
+                "port", port, "user", user, "database", "", "password", "", "driver.parameters", "",
+                "ssl.mode", "", "ssl.server.cert", "", "batch.size", ""));
+        assertEquals(host, conf.host());
+        assertEquals(Integer.valueOf(port), conf.port());
+        assertEquals(user, conf.user());
+        assertNull(conf.database());
+        assertNull(conf.password());
+        assertNull(conf.driverParameters());
+        assertEquals("disable", conf.sslMode());
+        assertNull(conf.sslServerCert());
+        assertEquals(10000, conf.batchSize());
     }
 }


### PR DESCRIPTION
If the customer didn’t set a configuration, Fivetran passes an empty string instead of a null value.
It causes the wrong handling of the default values.