### PR TITLE
chore: Improve release process and version handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
-name: Test
+name: CI
 
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
+  push:
+    tags: ["v*"]
   schedule:
     - cron: "0 0 * * 0"
 
@@ -19,7 +21,7 @@ jobs:
         id: get_versions
         uses: singlestore-labs/singlestore-supported-versions@main
 
-  build:
+  test:
     needs: fetch-s2-versions
     runs-on: ubuntu-latest
 
@@ -72,3 +74,34 @@ jobs:
         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
         with:
           arguments: build
+
+  release:
+    permissions:
+      contents: write
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Copy common.proto file
+        run: wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/common.proto
+      - name: Copy destination_sdk.proto file
+        run: wget -O src/main/proto/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/destination_sdk.proto
+      - name: Set version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+      - name: Create JAR with Gradle
+        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+        with:
+          arguments: jar -Pversion=${{ env.VERSION }}
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          generate_release_notes: true
+          files: build/libs/singlestore-fivetran-destination-connector-*.jar
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@
 1. Download proto files
 
 ```
-wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/common.proto
-wget -O src/main/proto/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/destination_sdk.proto
+wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/common.proto
+wget -O src/main/proto/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/destination_sdk.proto
 ```
 
-2. Build the Jar
+2. Build the Jar (replace version with yours)
 
 ```
-gradle jar
+./gradlew jar -Pversion=<version>
 ```
 
-2. Run the Jar
+2. Run the Jar (replace version with yours)
 
 ```
-java -jar build/libs/singlestore-fivetran-destination-connector-3.0.1.jar
+java -jar build/libs/singlestore-fivetran-destination-connector-<version>.jar
 ```
 
 ## Steps for running Java tests
@@ -48,14 +48,14 @@ export ROOT_PASSWORD="YOUR SINGLESTORE ROOT PASSWORD"
 3. Download proto files
 
 ```
-wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/common.proto
-wget -O src/main/proto/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/v2/destination_sdk.proto
+wget -O src/main/proto/common.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/common.proto
+wget -O src/main/proto/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/destination_sdk.proto
 ```
 
 4. Run tests
 
 ```
-gradle build
+./gradlew build
 ```
 
 ## Steps for using Destination tester
@@ -75,3 +75,34 @@ create database tester;
 ```
 docker run --mount type=bind,source=<PATH TO PROJECT>/data-folder,target=/data -a STDIN -a STDOUT -a STDERR -it -e WORKING_DIR=./data-folder -e GRPC_HOSTNAME=localhost --network=host us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:<tag> --tester-type destination --port 50052
 ```
+
+## Release process
+
+To release a new version:
+
+1. Push a version tag using semantic versioning with a `v` prefix (`v<major>.<minor>.<patch>`, for example `v1.2.3`):
+
+   ```bash
+   git tag v1.0.1
+   git push origin v1.0.1
+   ```
+
+   The package version is derived from the tag (the leading `v` is stripped). This triggers the [CI workflow](.github/workflows/ci.yml), which:
+
+   - Runs the test matrix
+   - Builds the connector JAR with the release version
+   - Creates a [GitHub Release](https://github.com/singlestore-labs/singlestore-fivetran-destination/releases) with auto-generated release notes and the JAR (`singlestore-fivetran-destination-connector-<version>.jar`)
+
+2. After the GitHub Release is published, post a message in the `#ext-fivetran-singlestore` Slack channel asking Fivetran to upload the updated connector. Replace `<version>` with the release version (for example, `1.2.9` for tag `v1.2.9`):
+
+   ```
+   Hi,
+
+   We have released SingleStore Fivetran Destination Connector <version>.
+   GitHub Release: https://github.com/singlestore-labs/singlestore-fivetran-destination/releases/tag/v<version>
+
+   Could you please upload the updated version?
+
+   Thanks,
+   <Your name>
+   ```

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
     mavenCentral()
 }
 
-version = '3.0.1'
+version = providers.gradleProperty('version').orElse('0.0.0-SNAPSHOT').get()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
 - removed hard-coded version
 - added release workflow
 - added release guide to the README

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI, build metadata, and documentation; no connector runtime or data-path logic is modified.
> 
> **Overview**
> **Releases are now tag-driven** instead of relying on a hard-coded connector version in `build.gradle`.
> 
> The project version comes from the Gradle `-Pversion` property, defaulting to `0.0.0-SNAPSHOT` when unset. CI renames the main job to `test`, runs on `v*` tag pushes, and adds a **`release` job** (after tests) that strips the `v` from the tag, builds the JAR with that version, and publishes a GitHub Release with generated notes and the connector artifact.
> 
> The **README** documents the tag-and-push release flow, switches Fivetran proto downloads to the `main` branch, and updates local build/run steps to use `./gradlew` with an explicit version placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee3486b41947f8463089b3f286e18d5b5ee8091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->