### PR TITLE
chore: Add signing step to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
 
   release:
     permissions:
+      id-token: write
       contents: write
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
@@ -94,14 +95,64 @@ jobs:
       - name: Copy destination_sdk.proto file
         run: wget -O src/main/proto/destination_sdk.proto https://raw.githubusercontent.com/fivetran/fivetran_sdk/main/destination_sdk.proto
       - name: Set version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
       - name: Create JAR with Gradle
         uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
         with:
-          arguments: jar -Pversion=${{ env.VERSION }}
+          arguments: jar -Pversion=${{ env.RELEASE_VERSION }}
+      - name: Install Jsign
+        if: ${{ success() }}
+        run: |
+          wget https://github.com/ebourg/jsign/releases/download/7.0/jsign_7.0_all.deb
+          sudo dpkg -i jsign_7.0_all.deb
+      - name: Azure Login
+        if: ${{ success() }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign JARs with Jsign
+        if: ${{ success() }}
+        run: |
+          AZURE_ACCESS_TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken -o tsv)
+          JSIGN_JAR=/usr/share/jsign/jsign-7.0.jar
+          ENDPOINT="${{ vars.AZURE_SIGNING_ENDPOINT }}"
+          ALIAS="${{ vars.AZURE_SIGNING_ACCOUNT }}/${{ vars.AZURE_SIGNING_PROFILE }}"
+          jarsigner \
+            -J-cp -J"$JSIGN_JAR" -J--add-modules -Jjava.sql \
+            -providerClass net.jsign.jca.JsignJcaProvider \
+            -providerArg "$ENDPOINT" \
+            -keystore NONE \
+            -storetype TRUSTEDSIGNING \
+            -storepass "$AZURE_ACCESS_TOKEN" \
+            -tsa "http://timestamp.acs.microsoft.com" \
+            "build/libs/singlestore-fivetran-source-connector-${{ env.RELEASE_VERSION }}.jar" "$ALIAS"
+      # The Trusted Signing root is not shipped in the JDK truststore, so without
+      # it jarsigner reports the signer and timestamp chains as unverifiable.
+      - name: Trust the Azure Trusted Signing root CA
+        if: ${{ success() }}
+        run: |
+          EXPECTED_SHA256="53:67:F2:0C:7A:DE:0E:2B:CA:79:09:15:05:6D:08:6B:72:0C:33:C1:FA:2A:26:61:AC:F7:87:E3:29:2E:12:70"
+          curl -fsSL -o msroot2020.crt \
+            "https://www.microsoft.com/pkiops/certs/Microsoft%20Identity%20Verification%20Root%20Certificate%20Authority%202020.crt"
+          ACTUAL_SHA256=$(openssl x509 -inform DER -in msroot2020.crt -noout -fingerprint -sha256 | cut -d= -f2)
+          if [[ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]]; then
+            echo "Unexpected root CA fingerprint: $ACTUAL_SHA256" >&2
+            exit 1
+          fi
+          # setup-java installs the JDK as root; the runner user cannot write cacerts.
+          sudo "$JAVA_HOME/bin/keytool" -importcert -noprompt \
+            -alias microsoft-identity-verification-root-ca-2020 \
+            -keystore "$JAVA_HOME/lib/security/cacerts" \
+            -storepass changeit \
+            -file msroot2020.crt
+      - name: Verify signed JARs
+        if: ${{ success() }}
+        run: jarsigner -verify "build/libs/singlestore-fivetran-source-connector-${{ env.RELEASE_VERSION }}.jar" -strict
       - name: Release on GitHub
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
-          files: build/libs/singlestore-fivetran-destination-connector-*.jar
+          files: build/libs/singlestore-fivetran-destination-connector-${{ env.RELEASE_VERSION }}.jar
           fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
             -storetype TRUSTEDSIGNING \
             -storepass "$AZURE_ACCESS_TOKEN" \
             -tsa "http://timestamp.acs.microsoft.com" \
-            "build/libs/singlestore-fivetran-source-connector-${{ env.RELEASE_VERSION }}.jar" "$ALIAS"
+            "build/libs/singlestore-fivetran-destination-connector-${{ env.RELEASE_VERSION }}.jar" "$ALIAS"
       # The Trusted Signing root is not shipped in the JDK truststore, so without
       # it jarsigner reports the signer and timestamp chains as unverifiable.
       - name: Trust the Azure Trusted Signing root CA
@@ -149,7 +149,7 @@ jobs:
             -file msroot2020.crt
       - name: Verify signed JARs
         if: ${{ success() }}
-        run: jarsigner -verify "build/libs/singlestore-fivetran-source-connector-${{ env.RELEASE_VERSION }}.jar" -strict
+        run: jarsigner -verify "build/libs/singlestore-fivetran-destination-connector-${{ env.RELEASE_VERSION }}.jar" -strict
       - name: Release on GitHub
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ To release a new version:
 
    - Runs the test matrix
    - Builds the connector JAR with the release version
-   - Creates a [GitHub Release](https://github.com/singlestore-labs/singlestore-fivetran-destination/releases) with auto-generated release notes and the JAR (`singlestore-fivetran-destination-connector-<version>.jar`)
+   - Signs the JAR with Azure Trusted Signing and verifies the signature
+   - Creates a [GitHub Release](https://github.com/singlestore-labs/singlestore-fivetran-destination/releases) with auto-generated release notes and the signed JAR (`singlestore-fivetran-destination-connector-<version>.jar`)
 
 2. After the GitHub Release is published, post a message in the `#ext-fivetran-singlestore` Slack channel asking Fivetran to upload the updated connector. Replace `<version>` with the release version (for example, `1.2.9` for tag `v1.2.9`):
 


### PR DESCRIPTION
Use Azure trusted signing for the distributed JAR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release pipeline now depends on Azure secrets/vars and OIDC; misconfiguration could block releases or publish unsigned artifacts if steps fail silently (though verify is strict).
> 
> **Overview**
> The **release** job in CI now **signs** the connector JAR with **Azure Trusted Signing** before publishing to GitHub Releases.
> 
> It grants `id-token: write`, renames the version env to `RELEASE_VERSION`, installs **Jsign**, logs into Azure, signs the versioned JAR via `jarsigner` with the Trusted Signing provider, imports the Microsoft root CA so verification works on the runner, and runs **strict** `jarsigner -verify`. The GitHub Release step uploads the **single** versioned JAR instead of a wildcard.
> 
> The README release section documents signing and verification and notes that releases ship a **signed** JAR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c9fd4ee18298df1f0d68be7894a62383188f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->